### PR TITLE
Adding license declaration to spec

### DIFF
--- a/rubydora.gemspec
+++ b/rubydora.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Fedora Commons REST API ruby library'
   s.description = 'Fedora Commons REST API ruby library'
   s.homepage    = 'http://github.com/projecthydra/rubydora'
+  s.license     = 'Apache-2.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
We are looking at leveraging [Pivotal Lab's LicenseFinder](https://github.com/pivotal/LicenseFinder#a-plea-to-package-authors-and-maintainers)
for reviewing the licenses of our dependencies. Rubydora's returns an
unknown for its license.

(It scans the gemspec and found nothing, it also compared the
LICENSE.txt against the known templates and they were not exact
matches)
