### PR TITLE
Add Dockerfile and install.properties for fcrepo3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM amazoncorretto:8
+
+ENV FEDORA_HOME /opt/fedora
+ENV CATALINA_HOME /opt/fedora/tomcat
+ENV PATH $CATALINA_HOME/bin:$PATH
+
+RUN curl -L http://sourceforge.net/projects/fedora-commons/files/fedora/3.8.1/fcrepo-installer-3.8.1.jar/download -o /opt/fcrepo-installer.jar
+
+COPY docker/install.properties /opt/install.properties
+RUN java -jar /opt/fcrepo-installer.jar /opt/install.properties
+
+EXPOSE 8983
+WORKDIR $FEDORA_HOME
+
+CMD ["catalina.sh", "run"]

--- a/README.md
+++ b/README.md
@@ -67,6 +67,27 @@ gem install rubydora
 => true
 ```
 
+## Running the Tests
+
+There is a Dockerfile included here to build a container that runs fcrepo3. It
+will listen on port 8983, so no additional configuration is required. You can
+run the continuous integration suite or the specs directly. An example of
+starting the server and running just the specs is included here:
+
+```
+docker build -t samvera/fcrepo3:latest .
+RUBYDORA_ID=$(docker run -d -p 8983:8983 samvera/fcrepo3:latest)
+bundle exec rspec && docker kill $RUBYDORA_ID
+```
+
+There are also Rake tasks for building the image and running the suite against
+a container:
+
+```
+bundle exec rake docker:build
+bundle exec rake docker:spec
+```
+
 ## Contributing to rubydora
 
 *   Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet

--- a/Rakefile
+++ b/Rakefile
@@ -61,6 +61,24 @@ task :ci => 'jetty:clean' do
   raise "test failures: #{error}" if error
 end
 
+desc 'Execute specs against Fedora under Docker'
+task 'docker:build' do
+  system("docker build -t samvera/fcrepo3:latest .")
+end
+
+desc 'Execute specs against Fedora under Docker'
+task 'docker:spec' do
+  container = `docker run -d -p 8983:8983 samvera/fcrepo3:latest`.chomp
+  puts "Waiting 10s for Fedora to start..."
+  sleep 10
+  Rake::Task['spec'].invoke
+  killed = `docker kill #{container}`.chomp
+  unless container == killed
+    puts "Container (#{container}) not cleaned up successfully..."
+    puts "It is likely still running and binding port 8983."
+  end
+end
+
 desc 'Execute specs with coverage'
 task :coverage do
   # Put spec opts in a file named .rspec in root

--- a/docker/install.properties
+++ b/docker/install.properties
@@ -1,0 +1,28 @@
+#Install Options
+#Wed Jul 31 20:33:30 UTC 2019
+ri.enabled=false
+apia.auth.required=false
+messaging.enabled=false
+database.jdbcDriverClass=org.apache.derby.jdbc.EmbeddedDriver
+upstream.auth.enabled=false
+ssl.available=false
+database.jdbcURL=jdbc\:derby\:/opt/fedora/derby/fedora3;create\=true
+database.password=fedoraAdmin
+database.username=fedoraAdmin
+fesl.authz.enabled=false
+tomcat.shutdown.port=8005
+deploy.local.services=true
+xacml.enabled=false
+tomcat.http.port=8983
+fedora.serverHost=localhost
+database=included
+database.driver=included
+fedora.serverContext=fedora
+llstore.type=akubra-fs
+tomcat.home=/opt/fedora/tomcat
+fesl.authn.enabled=true
+fedora.home=/opt/fedora
+install.type=quick
+servlet.engine=included
+apim.ssl.required=false
+fedora.admin.pass=fedoraAdmin


### PR DESCRIPTION
Resolves #123

This may not be the ultimate home for these files, but included are a
simple Dockerfile and install.properties for noninteractive installation
of fcrepo3. Running the container starts Tomcat on port 8983, as is
generally expected in the test suite.

There are also a couple of basic Rake tasks to help with building and
running against the container.