### PR TITLE
Updating the Product Owner information in preparation for the 2022 autumn request for maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,25 @@
 Rubydora is a low-level Fedora Commons REST API consumer, providing direct
 access to REST API methods, as well as a primitive ruby abstraction.
 
-[![CircleCI](https://circleci.com/gh/samvera/rubydora.svg?style=svg)](https://circleci.com/gh/samvera/rubydora)
-[<img src="https://badge.fury.io/rb/rubydora.png" alt="Gem Version"/>](http://badge.fury.io/rb/rubydora)
+Code:
+[![Gem Version](https://badge.fury.io/rb/rubydora.png)](http://badge.fury.io/rb/rubydora)
+[![Build Status](https://circleci.com/gh/samvera/rubydora.svg?style=svg)](https://circleci.com/gh/samvera/rubydora)
 [![Coverage Status](https://coveralls.io/repos/github/samvera/rubydora/badge.svg?branch=main)](https://coveralls.io/github/samvera/rubydora?branch=main)
 
-Jump in: [![Slack Status](http://slack.samvera.org/badge.svg)](http://slack.samvera.org/)
+Docs:
+[![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
+[![Apache 2.0 License](http://img.shields.io/badge/APACHE2-license-blue.svg)](./LICENSE.txt)
 
-## Primary Contacts
+Community Support: [![Samvera Community Slack](https://img.shields.io/badge/samvera-slack-blueviolet)](http://slack.samvera.org/)
+
+## Product Owner & Maintenance
+
+`rubydora` was a Core Component of the Samvera Community. Given a decline in available labor required for maintenance, this project no longer has a dedicated Product Owner. The documentation for what this means can be found [here](http://samvera.github.io/core_components.html#requirements-for-a-core-component).
 
 ### Product Owner
-[Justin Coyne](https://github.com/jcoyne)
+**Vacant**
+
+_Until a Product Owner has been identified, we ask that you please direct all requests for support, bug reports, and general questions to the [`#dev` Channel on the Samvera Slack](https://samvera.slack.com/app_redirect?channel=dev)._
 
 ## Help
 


### PR DESCRIPTION
This is necessary in order to request from the community renewed efforts for maintenance, and to direct those outside of the community to the Samvera Slack.