### PR TITLE
Test on latest ruby and rails versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,52 +56,73 @@ workflows:
   version: 2
   ci:
     jobs:
+      # Rails 7.1
+      - test:
+          name: "ruby3-3_rails7-1"
+          ruby_version: 3.3.0
+          rails_version: 7.1.3
+      - test:
+          name: "ruby3-2_rails7-1"
+          ruby_version: 3.2.3
+          rails_version: 7.1.3
+      - test:
+          name: "ruby3-1_rails7-1"
+          ruby_version: 3.1.4
+          rails_version: 7.1.3
+      - test:
+          name: "ruby3-0_rails7-1"
+          ruby_version: 3.0.6
+          rails_version: 7.1.3
       # Rails 7.0
       - test:
+          name: "ruby3-3_rails7-0"
+          ruby_version: 3.3.0
+          rails_version: 7.0.8
+      - test:
           name: "ruby3-2_rails7-0"
-          ruby_version: 3.2.0
-          rails_version: 7.0.4.1
+          ruby_version: 3.2.3
+          rails_version: 7.0.8
       - test:
           name: "ruby3-1_rails7-0"
-          ruby_version: 3.1.3
-          rails_version: 7.0.4.1
+          ruby_version: 3.1.4
+          rails_version: 7.0.8
       - test:
           name: "ruby3-0_rails7-0"
-          ruby_version: 3.0.5
-          rails_version: 7.0.4.1
+          ruby_version: 3.0.6
+          rails_version: 7.0.8
       # Rails 6.1
       - test:
           name: "ruby3-2_rails6-1"
-          ruby_version: 3.2.0
-          rails_version: 6.1.7.1
+          ruby_version: 3.2.3
+          rails_version: 6.1.7.6
       - test:
           name: "ruby3-1_rails6-1"
-          ruby_version: 3.1.3
-          rails_version: 6.1.7.1
+          ruby_version: 3.1.4
+          rails_version: 6.1.7.6
       - test:
           name: "ruby3-0_rails6-1"
-          ruby_version: 3.0.5
-          rails_version: 6.1.7.1
+          ruby_version: 3.0.6
+          rails_version: 6.1.7.6
       - test:
           name: "ruby2-7_rails6-1"
-          ruby_version: 2.7.7
-          rails_version: 6.1.7.1
+          ruby_version: 2.7.8
+          rails_version: 6.1.7.6
       # Rails 6.0
       - test:
           name: "ruby3-2_rails6-0"
-          ruby_version: 3.2.0
+          ruby_version: 3.2.3
           rails_version: 6.0.6.1
       - test:
           name: "ruby3-1_rails6-1"
-          ruby_version: 3.1.3
+          ruby_version: 3.1.4
           rails_version: 6.0.6.1
       - test:
           name: "ruby3-0_rails6-1"
-          ruby_version: 3.0.5
+          ruby_version: 3.0.6
           rails_version: 6.0.6.1
       - test:
           name: "ruby2-7_rails6-0"
-          ruby_version: 2.7.7
+          ruby_version: 2.7.8
           rails_version: 6.0.6.1
       - test:
           name: "ruby2-6_rails6-0"
@@ -114,7 +135,7 @@ workflows:
       # Rails 5.2
       - test:
           name: "ruby2-7_rails5-2"
-          ruby_version: 2.7.7
+          ruby_version: 2.7.8
           rails_version: 5.2.8.1
       - test:
           name: "ruby2-6_rails5-2"
@@ -127,7 +148,7 @@ workflows:
       # Rails 5.1
       - test:
           name: "ruby2-7_rails5-1"
-          ruby_version: 2.7.7
+          ruby_version: 2.7.8
           rails_version: 5.1.7
       - test:
           name: "ruby2-6_rails5-1"
@@ -148,52 +169,73 @@ workflows:
                 - main
 
     jobs:
+      # Rails 7.1
+      - test:
+          name: "ruby3-3_rails7-1"
+          ruby_version: 3.3.0
+          rails_version: 7.1.3
+      - test:
+          name: "ruby3-2_rails7-1"
+          ruby_version: 3.2.3
+          rails_version: 7.1.3
+      - test:
+          name: "ruby3-1_rails7-1"
+          ruby_version: 3.1.4
+          rails_version: 7.1.3
+      - test:
+          name: "ruby3-0_rails7-1"
+          ruby_version: 3.0.6
+          rails_version: 7.1.3
       # Rails 7.0
       - test:
+          name: "ruby3-3_rails7-0"
+          ruby_version: 3.3.0
+          rails_version: 7.0.8
+      - test:
           name: "ruby3-2_rails7-0"
-          ruby_version: 3.2.0
-          rails_version: 7.0.4.1
+          ruby_version: 3.2.3
+          rails_version: 7.0.8
       - test:
           name: "ruby3-1_rails7-0"
-          ruby_version: 3.1.3
-          rails_version: 7.0.4.1
+          ruby_version: 3.1.4
+          rails_version: 7.0.8
       - test:
           name: "ruby3-0_rails7-0"
-          ruby_version: 3.0.5
-          rails_version: 7.0.4.1
+          ruby_version: 3.0.6
+          rails_version: 7.0.8
       # Rails 6.1
       - test:
           name: "ruby3-2_rails6-1"
-          ruby_version: 3.2.0
-          rails_version: 6.1.7.1
+          ruby_version: 3.2.3
+          rails_version: 6.1.7.6
       - test:
           name: "ruby3-1_rails6-1"
-          ruby_version: 3.1.3
-          rails_version: 6.1.7.1
+          ruby_version: 3.1.4
+          rails_version: 6.1.7.6
       - test:
           name: "ruby3-0_rails6-1"
-          ruby_version: 3.0.5
-          rails_version: 6.1.7.1
+          ruby_version: 3.0.6
+          rails_version: 6.1.7.6
       - test:
           name: "ruby2-7_rails6-1"
-          ruby_version: 2.7.7
-          rails_version: 6.1.7.1
+          ruby_version: 2.7.8
+          rails_version: 6.1.7.6
       # Rails 6.0
       - test:
           name: "ruby3-2_rails6-0"
-          ruby_version: 3.2.0
+          ruby_version: 3.2.3
           rails_version: 6.0.6.1
       - test:
           name: "ruby3-1_rails6-1"
-          ruby_version: 3.1.3
+          ruby_version: 3.1.4
           rails_version: 6.0.6.1
       - test:
           name: "ruby3-0_rails6-1"
-          ruby_version: 3.0.5
+          ruby_version: 3.0.6
           rails_version: 6.0.6.1
       - test:
           name: "ruby2-7_rails6-0"
-          ruby_version: 2.7.7
+          ruby_version: 2.7.8
           rails_version: 6.0.6.1
       - test:
           name: "ruby2-6_rails6-0"
@@ -206,7 +248,7 @@ workflows:
       # Rails 5.2
       - test:
           name: "ruby2-7_rails5-2"
-          ruby_version: 2.7.7
+          ruby_version: 2.7.8
           rails_version: 5.2.8.1
       - test:
           name: "ruby2-6_rails5-2"
@@ -219,7 +261,7 @@ workflows:
       # Rails 5.1
       - test:
           name: "ruby2-7_rails5-1"
-          ruby_version: 2.7.7
+          ruby_version: 2.7.8
           rails_version: 5.1.7
       - test:
           name: "ruby2-6_rails5-1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,19 +145,6 @@ workflows:
           name: "ruby2-5_rails5-2"
           ruby_version: 2.5.9
           rails_version: 5.2.8.1
-      # Rails 5.1
-      - test:
-          name: "ruby2-7_rails5-1"
-          ruby_version: 2.7.8
-          rails_version: 5.1.7
-      - test:
-          name: "ruby2-6_rails5-1"
-          ruby_version: 2.6.10
-          rails_version: 5.1.7
-      - test:
-          name: "ruby2-5_rails5-1"
-          ruby_version: 2.5.9
-          rails_version: 5.1.7
 
   nightly:
     triggers:
@@ -258,16 +245,3 @@ workflows:
           name: "ruby2-5_rails5-2"
           ruby_version: 2.5.9
           rails_version: 5.2.8.1
-      # Rails 5.1
-      - test:
-          name: "ruby2-7_rails5-1"
-          ruby_version: 2.7.8
-          rails_version: 5.1.7
-      - test:
-          name: "ruby2-6_rails5-1"
-          ruby_version: 2.6.10
-          rails_version: 5.1.7
-      - test:
-          name: "ruby2-5_rails5-1"
-          ruby_version: 2.5.9
-          rails_version: 5.1.7

--- a/rubydora.gemspec
+++ b/rubydora.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'equivalent-xml'
   s.add_dependency 'mime-types'
   s.add_dependency 'activesupport'
-  s.add_dependency 'activemodel', '>= 4.2.10'
+  s.add_dependency 'activemodel', '>= 5.2'
   s.add_dependency 'hooks', '~> 0.3'
   s.add_dependency 'deprecation'
 


### PR DESCRIPTION
Part of https://github.com/samvera/maintenance/issues/159
Part of https://github.com/samvera/maintenance/issues/160

Tests were failing on rails 5.1 so I added a commit to drop support for rails versions < 5.2.  This may require a major release due to that change.